### PR TITLE
I sometimes get an exception on getting the combatant scene name in t…

### DIFF
--- a/scripts/floating-combat-toolbox.js
+++ b/scripts/floating-combat-toolbox.js
@@ -171,7 +171,7 @@ Hooks.on("renderCombatTracker", (combatTracker, html, data) => {
         const combatantID = this.dataset.combatantId;
         const combatant = game.combat.combatants.get(combatantID);
         const combatantSceneID = combatant.getFlag("floating-combat-toolbox", "sceneID");
-        const sceneName = game.scenes.get(combatantSceneID).name;
+        const sceneName = game.scenes.get(combatantSceneID)?.name||"(unknown)";
         $(this).prop("title", sceneName);
 
         if (game.settings.get("floating-combat-toolbox", "displaySceneName")) {


### PR DESCRIPTION
…he PF2 system

Could be a module/system interaction, but even so it seems better to just set scene name to "(unknown)" rather than crash if for some reason the flag can't be found on a combatant.